### PR TITLE
Leave output in trial demo notebook

### DIFF
--- a/notebooks/trial_specification_demo.ipynb
+++ b/notebooks/trial_specification_demo.ipynb
@@ -934,6 +934,7 @@
   }
  ],
  "metadata": {
+  "keep_output": true,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -949,7 +950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changing notebook metadata to leave output in the trial setup notebook. This is required if nbstripout is installed (as specified in the developer doc). Otherwise, it has not impact on the notebook.