### PR TITLE
Update import paths

### DIFF
--- a/notebooks/site_activation_demo.ipynb
+++ b/notebooks/site_activation_demo.ipynb
@@ -42,13 +42,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
     "import os\n",
-    "metis_path = os.path.join(os.path.split(os.path.abspath('.'))[0], 'py')\n",
-    "sys.path.append(metis_path)\n",
-    "sys.path.append(os.path.join(metis_path, 'metis'))\n",
-    "import site_activation_vis\n",
-    "import metis.io"
+    "from metis import site_activation_vis\n",
+    "from metis import io as metis_io"
    ]
   },
   {
@@ -173,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "original_ds = metis.io.load_ville_from_netcdf(file_path)\n",
+    "original_ds = metis_io.load_ville_from_netcdf(file_path)\n",
     "site_activation_vis.site_activation(original_ds)"
    ]
   },

--- a/py/metis/plot.py
+++ b/py/metis/plot.py
@@ -6,13 +6,13 @@
 
 """Functions for plotting incidence, recruitment, and events in Metis."""
 
-import colors_config as cc
+from metis import colors_config as cc
 import matplotlib as mpl
 import numpy as np
 import pandas as pd
-import plot_utils
+from metis import plot_utils
 import warnings
-import ville_config
+from metis import ville_config
 
 # All functions here take an axis argument and modify it in place.
 # Functions in plot_utils return arguments.

--- a/py/metis/plot_utils.py
+++ b/py/metis/plot_utils.py
@@ -6,13 +6,13 @@
 
 """Utils for plotting arrays in Metis."""
 
-import colors_config as cc
-import evaluation
+from metis import colors_config as cc
+from metis import evaluation
 import matplotlib as mpl
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 import numpy as np
-import ville_config
+from metis import ville_config
 import warnings
 import xarray as xr
 

--- a/py/metis/site_activation_vis.py
+++ b/py/metis/site_activation_vis.py
@@ -6,22 +6,22 @@
 
 """Vis to compare the impact of site activations on trial outcomes."""
 
-import colors_config
+from metis import colors_config
 import datetime
-import interactive_utils as int_utils
+from metis import interactive_utils as int_utils
 import ipywidgets as widgets
 import functools
-import metis.io
+from metis import io as metis_io
 import numpy as np
 import os
-import optimization
+from metis import optimization
 import pathlib
-import plot
-import plot_utils
-import sim
-import sim_scenarios
-import table_utils
-import ville_config
+from metis import plot
+from metis import plot_utils
+from metis import sim
+from metis import sim_scenarios
+from metis import table_utils
+from metis import ville_config
 
 """An interactive exploration of how site activations impact trial outcomes.
 
@@ -467,7 +467,7 @@ def save_activation(ds):
     file_path = ville_config.SAVE_FILE_PATH
     # Make dir if it doesn't exist
     pathlib.Path(file_path).mkdir(exist_ok=True)
-    metis.io.write_ville_to_netcdf(ds, os.path.join(file_path, file_name),
+    metis_io.write_ville_to_netcdf(ds, os.path.join(file_path, file_name),
                                    file_open_fn)
 
 def make_rso_buttons(ds, sum_box, loc_box, t_box, loc_dropdown, t_dropdown, status_button):

--- a/py/metis/table_utils.py
+++ b/py/metis/table_utils.py
@@ -7,7 +7,7 @@
 """Utils to implement sortable tables."""
 
 import pandas as pd
-import plot_utils
+from metis import plot_utils
 
 def sort_table(ds_first, da_participants, ds_last, sort_col):
     """Sort the table and return as a pd.DataFrame indexed by location.

--- a/py/metis/ville_config.py
+++ b/py/metis/ville_config.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
-import metis.io
+from metis import metis_io
 import numpy as np
 import os
 
@@ -12,7 +12,7 @@ import os
 LABELS_TO_DROP = ["under_60", "none", "other"] # Participant labels to not plot
 FIRST_PLOT_DAY = None
 SAVE_FILE_PATH = os.path.join(os.path.abspath(__file__).split('py')[0], 'act_villes')
-FILE_OPEN_FN = metis.io.open_fn
+FILE_OPEN_FN = metis_io.open_fn
 
 SUCCESS_DATES = slice(np.datetime64('2020-12-01'), np.datetime64('2021-02-28'))
 HIST_BIN_WIDTH = 4 # time units

--- a/py/metis/ville_config.py
+++ b/py/metis/ville_config.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
-from metis import metis_io
+from metis import io as metis_io
 import numpy as np
 import os
 


### PR DESCRIPTION
Update the import paths to include `from metis import X`. This allows us to remove the `sys.path.append` step in the site_activation notebook, and instead rely on the user's Python path.