### PR TITLE
Turn on TOC sidebar.

### DIFF
--- a/notebooks/site_activation_demo.ipynb
+++ b/notebooks/site_activation_demo.ipynb
@@ -214,6 +214,19 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,

--- a/notebooks/trial_specification_demo.ipynb
+++ b/notebooks/trial_specification_demo.ipynb
@@ -936,6 +936,19 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In Jupyter environments where the TOC extension is installed, such as Terra, these metadata changes will cause the TOC sidebar to display by default.