### PR TITLE
Support observation_delay of zero. Sanity check observation_delay.

### DIFF
--- a/metis/optimization.py
+++ b/metis/optimization.py
@@ -266,7 +266,7 @@ def optimize_params(c,
       optimization.
     verbose: if True, print some stuff.
   """
-  # Run non-differentiable simulation once, because they do more error checking.
+  # Run non-differentiable simulation once, because it does more error checking.
   participants = sim.recruitment(c)
   sim.control_arm_events(c, participants, incidence_scenarios)
 


### PR DESCRIPTION
In the differentiable version of control_arm_events, we need do the jax
analog of participants.shift(observation_delay). In the implementation,
doing this involved computing participants[:-observation_delay],
trimming the last few days off of the participants array. However, this
expression does the wrong thing with observation_delay is 0, returning
an empty array! This change fixes this bug.

Sanity checks on observation_delay have been added to the
non-differentiable version of control_arm_events.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR