### PR TITLE
Use newer versions of the GitHub actions.

### DIFF
--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -34,7 +34,7 @@ jobs:
         python-version: 3.7
 
     - name: Setup gcloud CLI
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       # TO REUSE THIS TEMPLATE, configure auth.
       # Step 1: Create a service account and store its key in GitHub as 'TERRA_SECRET' per these instructions:
       # https://github.com/google-github-actions/setup-gcloud/blob/master/setup-gcloud/README.md


### PR DESCRIPTION
Fixes publish to terra workflow that currently points to a version that no longer exists.